### PR TITLE
fixed undefined_vars detection in when option

### DIFF
--- a/sage_scan/process/variable_container.py
+++ b/sage_scan/process/variable_container.py
@@ -299,7 +299,7 @@ def extract_when_option_var_name(option_parts, is_failed_when=False):
     for p in option_parts:
         if "match(" in p or "default(" in p:
             continue
-        p = p.replace(")","").replace("(","")
+        p = p.replace(")","").replace("(","").replace("{", "").replace("}", "")
         if not p:
             continue
         if "=" in p or "<" in p or ">" in p:

--- a/sage_scan/process/variable_container.py
+++ b/sage_scan/process/variable_container.py
@@ -293,7 +293,7 @@ def check_when_option(options):
 
 def extract_when_option_var_name(option_parts, is_failed_when=False):
     used_vars = {}
-    ignore_words = ["defined", "undefined", "is", "not", "and", "or", "|", "in", "none"]
+    ignore_words = ["defined", "undefined", "is", "not", "and", "or", "|", "in", "none", "item"]
     boolean_vars = ["True", "true", "t", "yes", 'y', 'on', "False", "false", 'f', 'no', 'n', 'off']
     data_type_words = ["bool", "float", "int", "length"]
     for p in option_parts:
@@ -312,7 +312,10 @@ def extract_when_option_var_name(option_parts, is_failed_when=False):
             continue
         if p.startswith('"') or p.startswith("'"):
             continue
+        p = p.replace("\"", "")
         if p.isdigit():
+            continue
+        if check_if_magic_vars(p):
             continue
         if is_failed_when:
             used_vars[p] = {"original": p, "name": p, "in_failed_when": True}


### PR DESCRIPTION
Signed-off-by: Ruriko Kudo <rurikudo@ibm.com>

- fixed not to detect '{{' as undefined vars in when option
- fixed not to detect ansible magic words in when option